### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/LightspeedRelaySmartAgent/LightspeedRelaySmartAgent.pkg.recipe
+++ b/LightspeedRelaySmartAgent/LightspeedRelaySmartAgent.pkg.recipe
@@ -133,10 +133,10 @@ exit 0</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                  <key>pkgname</key>
+                  <string>%NAME%-%version%</string>
                   <key>pkgroot</key>
         					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
                   <key>pkgdir</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).