### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/GarageBand/GarageBand.munki.recipe
+++ b/GarageBand/GarageBand.munki.recipe
@@ -44,10 +44,6 @@
 					<key>minimum_os_version</key>
 					<string>%os_minimum%</string>
 				</dict>
-				<key>pkg_path</key>
-				<string>%pkg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>


### PR DESCRIPTION
`pkg_path` and `repo_subdirectory` are not valid arguments for [MunkiPkginfoMerger](https://github.com/autopkg/autopkg/wiki/Processor-MunkiPkginfoMerger).